### PR TITLE
Support for running locally in Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,56 @@
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
+
+require 'fileutils'
+
+Vagrant.require_version ">= 1.9.0"
+
+# Defaults for config options defined in CONFIG
+$num_controllers = 1
+$num_workers = ENV["WORKERS"].to_i
+
+$vm_gui = false
+$vm_memory = 1024
+$vm_cpus = 1
+$subnet = "172.17.8"
+
+Vagrant.configure("2") do |config|
+  # always use Vagrants insecure key
+  config.ssh.insert_key = false
+  config.vm.box = "bento/ubuntu-16.04"
+  config.ssh.username = "vagrant"
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+  ["vmware_fusion", "vmware_workstation"].each do |vmware|
+    config.vm.provider vmware do |v|
+      v.vmx['memsize'] = $vm_memory
+      v.vmx['numvcpus'] = $vm_cpus
+    end
+  end
+  config.vm.provider :virtualbox do |vb|
+    vb.gui = $vm_gui
+    vb.memory = $vm_memory
+    vb.cpus = $vm_cpus
+  end
+
+  # controller node
+  config.vm.define vm_name = "controller-node" do |config|
+    config.vm.hostname = vm_name
+    ip = "#{$subnet}.100"
+    config.vm.network :private_network, ip: ip
+    config.vm.provision "shell", path: "vagrant/_configure.sh"
+  end
+
+  # workers
+  (0..$num_workers).each do |i|
+    config.vm.define vm_name = "worker-node-#{i}" do |config|
+      config.vm.hostname = vm_name
+      ip = "#{$subnet}.#{i+101}"
+      config.vm.network :private_network, ip: ip
+      config.vm.provision "shell", path: "vagrant/_configure.sh"
+    end
+  end
+
+end

--- a/scripts/generate_certificates.sh
+++ b/scripts/generate_certificates.sh
@@ -112,6 +112,11 @@ generate_certificates() {
 		# get the controller internal ips
 		internal_ips=$(az vm list-ip-addresses -g "$RESOURCE_GROUP" -o table | grep controller | awk '{print $3}' | tr -d '[:space:]' | tr '\n' ',' | sed 's/,*$//g')
 	fi
+	# Vagrant
+	if [[ "$CLOUD_PROVIDER" == "vagrant" ]]; then
+		internal_ips=172.17.8.100
+		public_address=172.17.8.100
+	fi
 
 	# create the kube-apiserver client certificate
 	# 	outputs: kubernetes-key.pem kubernetes.pem

--- a/scripts/generate_configuration_files.sh
+++ b/scripts/generate_configuration_files.sh
@@ -18,6 +18,10 @@ generate_configuration_files() {
 	if [[ "$CLOUD_PROVIDER" == "azure" ]]; then
 		internal_ip=$(az vm list-ip-addresses -g "$RESOURCE_GROUP" -o table | grep controller | awk '{print $3}' | tr -d '[:space:]' | tr '\n' ',' | sed 's/,*$//g')
 	fi
+	# Vagrant
+	if [[ "$CLOUD_PROVIDER" == "vagrant" ]]; then
+		internal_ip=172.17.8.100
+	fi
 
 	# Generate each workers kubeconfig
 	# 	outputs: worker-0.kubeconfig worker-1.kubeconfig worker-2.kubeconfig

--- a/scripts/install_etcd.sh
+++ b/scripts/install_etcd.sh
@@ -19,8 +19,14 @@ install_etcd() {
 
 	# get the internal ip
 	# this is cloud provider specific
+	# Vagrant
+	if grep vagrant ~/.ssh/authorized_keys > /dev/null; then
+		internal_ip="172.17.8.100"
+	fi
 	# Google Cloud
-	internal_ip=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip || true)
+	if [[ -z "$internal_ip" ]]; then
+		internal_ip=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip || true)
+  fi
 	# Azure
 	if [[ -z "$internal_ip" ]]; then
 		internal_ip=$(curl -H "Metadata:true" "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-08-01&format=text")

--- a/scripts/install_kubernetes_controller.sh
+++ b/scripts/install_kubernetes_controller.sh
@@ -22,13 +22,18 @@ install_kubernetes_controller() {
 
 	# get the internal ip
 	# this is cloud provider specific
+	# Vagrant
+	if grep vagrant ~/.ssh/authorized_keys > /dev/null; then
+		internal_ip="172.17.8.100"
+	fi
 	# Google Cloud
-	internal_ip=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip || true)
+	if [[ -z "$internal_ip" ]]; then
+		internal_ip=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip || true)
+  fi
 	# Azure
 	if [[ -z "$internal_ip" ]]; then
 		internal_ip=$(curl -H "Metadata:true" "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-08-01&format=text")
 	fi
-
 	# update the kube-apiserver systemd service file
 	sed -i "s/INTERNAL_IP/${internal_ip}/g" /etc/systemd/system/kube-apiserver.service
 

--- a/scripts/install_kubernetes_worker.sh
+++ b/scripts/install_kubernetes_worker.sh
@@ -113,6 +113,9 @@ install_kubernetes_worker(){
 	if [[ "$CLOUD_PROVIDER" == "google" ]]; then
 		sudo apt-get -y install socat
 	fi
+	if [[ "$CLOUD_PROVIDER" == "vagrant" ]]; then
+		sudo apt-get -y install socat
+	fi
 
 	install_cni
 	if [[ "$CLOUD_PROVIDER" == "azure" ]]; then

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -7,16 +7,28 @@ set -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+export SSH_OPTIONS="${SSH_OPTIONS} -i ${SSH_KEYFILE}"
+
+
 # get the controller node public ip address
 # this is cloud provider specific
 # Google Cloud
 if [[ "$CLOUD_PROVIDER" == "google" ]]; then
 	controller_ip=$(gcloud compute instances describe "$CONTROLLER_NODE_NAME" --format 'value(networkInterfaces[0].accessConfigs[0].natIP)')
 	#controller_ip=$(gcloud compute addresses describe "$PUBLIC_IP_NAME" --region "$REGION" --format 'value(address)')
-fi
+
 # Azure
-if [[ "$CLOUD_PROVIDER" == "azure" ]]; then
+elif [[ "$CLOUD_PROVIDER" == "azure" ]]; then
 	controller_ip=$(az network public-ip show -g "$RESOURCE_GROUP" --name "$PUBLIC_IP_NAME" --query 'ipAddress' -o tsv | tr -d '[:space:]')
+
+# Vagrant
+elif [[ "$CLOUD_PROVIDER" == "vagrant" ]]; then
+	controller_ip=controller-node
+
+# none ?????
+else
+	echo need to be install on a valid cloud
+	exit 1
 fi
 
 echo "Provisioning kubernetes cluster for resource group $RESOURCE_GROUP..."
@@ -31,7 +43,7 @@ do_certs(){
 	echo "Certificates successfully generated in ${CERTIFICATE_TMP_DIR}!"
 
 	echo "Copying certs to controller node..."
-	scp -i "$SSH_KEYFILE" "${CERTIFICATE_TMP_DIR}/ca.pem" "${CERTIFICATE_TMP_DIR}/ca-key.pem" "${CERTIFICATE_TMP_DIR}/kubernetes.pem" "${CERTIFICATE_TMP_DIR}/kubernetes-key.pem" "${VM_USER}@${controller_ip}":~/
+	scp ${SSH_OPTIONS} "${CERTIFICATE_TMP_DIR}/ca.pem" "${CERTIFICATE_TMP_DIR}/ca-key.pem" "${CERTIFICATE_TMP_DIR}/kubernetes.pem" "${CERTIFICATE_TMP_DIR}/kubernetes-key.pem" "${VM_USER}@${controller_ip}":~/
 
 	echo "Copying certs to worker nodes..."
 	for i in $(seq 0 "$WORKERS"); do
@@ -47,9 +59,13 @@ do_certs(){
 		if [[ "$CLOUD_PROVIDER" == "azure" ]]; then
 			external_ip=$(az vm show -g "$RESOURCE_GROUP" -n "$instance" --show-details --query 'publicIps' -o tsv | tr -d '[:space:]')
 		fi
+		# Vagrant
+	  if [[ "$CLOUD_PROVIDER" == "vagrant" ]]; then
+			external_ip=${instance}
+		fi
 
 		# Copy the certificates
-		scp -i "$SSH_KEYFILE" "${CERTIFICATE_TMP_DIR}/ca.pem" "${CERTIFICATE_TMP_DIR}/${instance}-key.pem" "${CERTIFICATE_TMP_DIR}/${instance}.pem" "${VM_USER}@${external_ip}":~/
+		scp ${SSH_OPTIONS} "${CERTIFICATE_TMP_DIR}/ca.pem" "${CERTIFICATE_TMP_DIR}/${instance}-key.pem" "${CERTIFICATE_TMP_DIR}/${instance}.pem" "${VM_USER}@${external_ip}":~/
 	done
 }
 
@@ -59,7 +75,6 @@ do_kubeconfigs(){
 	source "${DIR}/generate_configuration_files.sh"
 	generate_configuration_files
 	echo "Kubeconfigs successfully generated in ${KUBECONFIG_TMP_DIR}!"
-
 	echo "Copying kubeconfigs to worker nodes..."
 	for i in $(seq 0 "$WORKERS"); do
 		instance="worker-node-${i}"
@@ -74,9 +89,13 @@ do_kubeconfigs(){
 		if [[ "$CLOUD_PROVIDER" == "azure" ]]; then
 			external_ip=$(az vm show -g "$RESOURCE_GROUP" -n "$instance" --show-details --query 'publicIps' -o tsv | tr -d '[:space:]')
 		fi
+		# Vagrant
+		if [[ "$CLOUD_PROVIDER" == "vagrant" ]]; then
+			external_ip=${instance}
+		fi
 
 		# Copy the kubeconfigs
-		scp -i "$SSH_KEYFILE" "${KUBECONFIG_TMP_DIR}/${instance}.kubeconfig" "${KUBECONFIG_TMP_DIR}/kube-proxy.kubeconfig" "${VM_USER}@${external_ip}":~/
+		scp ${SSH_OPTIONS} "${KUBECONFIG_TMP_DIR}/${instance}.kubeconfig" "${KUBECONFIG_TMP_DIR}/kube-proxy.kubeconfig" "${VM_USER}@${external_ip}":~/
 	done
 }
 
@@ -88,64 +107,65 @@ do_encryption_config(){
 	echo "Encryption config successfully generated in ${ENCRYPTION_CONFIG}!"
 
 	echo "Copying encryption config to controller node..."
-	scp -i "$SSH_KEYFILE" "$ENCRYPTION_CONFIG" "${VM_USER}@${controller_ip}":~/
+	scp ${SSH_OPTIONS} "$ENCRYPTION_CONFIG" "${VM_USER}@${controller_ip}":~/
 }
 
 do_etcd(){
 	echo "Moving certficates to correct location for etcd on controller node..."
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" sudo mkdir -p /etc/etcd/
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" sudo cp ca.pem kubernetes-key.pem kubernetes.pem /etc/etcd/
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" sudo mkdir -p /etc/etcd/
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" sudo cp ca.pem kubernetes-key.pem kubernetes.pem /etc/etcd/
 
 	echo "Copying etcd.service to controller node..."
-	scp -i "$SSH_KEYFILE" "${DIR}/../etc/systemd/system/etcd.service" "${VM_USER}@${controller_ip}":~/
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" sudo mkdir -p /etc/systemd/system/
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" sudo mv etcd.service /etc/systemd/system/
+	scp ${SSH_OPTIONS} "${DIR}/../etc/systemd/system/etcd.service" "${VM_USER}@${controller_ip}":~/
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" sudo mkdir -p /etc/systemd/system/
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" sudo mv etcd.service /etc/systemd/system/
 
 	echo "Copying etcd install script to controller node..."
-	scp -i "$SSH_KEYFILE" "${DIR}/install_etcd.sh" "${VM_USER}@${controller_ip}":~/
+	scp ${SSH_OPTIONS} "${DIR}/install_etcd.sh" "${VM_USER}@${controller_ip}":~/
 
 	echo "Running install_etcd.sh on controller node..."
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" sudo ./install_etcd.sh
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" sudo ./install_etcd.sh
 
 	# cleanup the script after install
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" rm install_etcd.sh
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" rm install_etcd.sh
 
 	# TODO: make this less shitty and not a sleep
 	# sanity check for etcd
-	sleep 5
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" ETCDCTL_API=3 etcdctl member list
+	while ! ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" ETCDCTL_API=3 etcdctl member list; do
+		sleep 5
+	done
 }
 
 do_k8s_controller(){
 	echo "Moving certficates to correct location for k8s on controller node..."
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" sudo mkdir -p /var/lib/kubernetes/
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" sudo mv ca.pem kubernetes-key.pem kubernetes.pem ca-key.pem encryption-config.yaml /var/lib/kubernetes/
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" sudo mkdir -p /var/lib/kubernetes/
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" sudo mv ca.pem kubernetes-key.pem kubernetes.pem ca-key.pem encryption-config.yaml /var/lib/kubernetes/
 
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" sudo mkdir -p /etc/systemd/system/
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" sudo mkdir -p /etc/systemd/system/
 	services=( kube-apiserver.service kube-scheduler.service kube-controller-manager.service )
 	for service in "${services[@]}"; do
 		echo "Copying $service to controller node..."
-		scp -i "$SSH_KEYFILE" "${DIR}/../etc/systemd/system/${service}" "${VM_USER}@${controller_ip}":~/
-		ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" sudo mv "$service" /etc/systemd/system/
+		scp ${SSH_OPTIONS} "${DIR}/../etc/systemd/system/${service}" "${VM_USER}@${controller_ip}":~/
+		ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" sudo mv "$service" /etc/systemd/system/
 	done
 
 	echo "Copying k8s controller install script to controller node..."
-	scp -i "$SSH_KEYFILE" "${DIR}/install_kubernetes_controller.sh" "${VM_USER}@${controller_ip}":~/
+	scp ${SSH_OPTIONS} "${DIR}/install_kubernetes_controller.sh" "${VM_USER}@${controller_ip}":~/
 
 	echo "Running install_kubernetes_controller.sh on controller node..."
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" sudo ./install_kubernetes_controller.sh
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" sudo ./install_kubernetes_controller.sh
 
 	# cleanup the script after install
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" rm install_kubernetes_controller.sh
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" rm install_kubernetes_controller.sh
 
 	echo "Copying k8s rbac configs to controller node..."
-	scp -i "$SSH_KEYFILE" "${DIR}/../etc/cluster-role-"*.yaml "${VM_USER}@${controller_ip}":~/
+	scp ${SSH_OPTIONS} "${DIR}/../etc/cluster-role-"*.yaml "${VM_USER}@${controller_ip}":~/
 
 	echo "Copying k8s pod configs to controller node..."
-	scp -i "$SSH_KEYFILE" "${DIR}/../etc/pod-"*.yaml "${VM_USER}@${controller_ip}":~/
+	scp ${SSH_OPTIONS} "${DIR}/../etc/pod-"*.yaml "${VM_USER}@${controller_ip}":~/
 
 	echo "Copying k8s kube-dns config to controller node..."
-	scp -i "$SSH_KEYFILE" "${DIR}/../etc/kube-dns.yaml" "${VM_USER}@${controller_ip}":~/
+	scp ${SSH_OPTIONS} "${DIR}/../etc/kube-dns.yaml" "${VM_USER}@${controller_ip}":~/
 
 	# get the internal ip for the instance
 	# this is cloud provider specific
@@ -157,6 +177,10 @@ do_k8s_controller(){
 	if [[ "$CLOUD_PROVIDER" == "azure" ]]; then
 		internal_ip=$(az vm show -g "$RESOURCE_GROUP" -n "$CONTROLLER_NODE_NAME" --show-details --query 'privateIps' -o tsv | tr -d '[:space:]')
 	fi
+  # Vagrant
+	if [[ "$CLOUD_PROVIDER" == "vagrant" ]]; then
+		internal_ip=172.17.8.100
+	fi
 
 	# configure cilium to use etcd tls
 	tmpd=$(mktemp -d)
@@ -167,33 +191,44 @@ do_k8s_controller(){
 	sed -i "s#INTERNAL_IP#${internal_ip}#" "$ciliumconfig"
 
 	echo "Copying k8s cilium config to controller node..."
-	scp -i "$SSH_KEYFILE" "$ciliumconfig" "${VM_USER}@${controller_ip}":~/
+	scp ${SSH_OPTIONS} "$ciliumconfig" "${VM_USER}@${controller_ip}":~/
 
 	# cleanup
 	rm -rf "$tmpd"
 
 	# wait for kube-apiserver service to come up
 	# TODO: make this not a shitty sleep you goddamn savage
-	sleep 10
+  echo "Waiting for kube-apiserver"
+	while ! ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" kubectl get componentstatuses > /dev/null; do
+		echo -n "."
+		sleep 10
+	done
+	echo "."
 
 	# get the component statuses for sanity
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" kubectl get componentstatuses
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" kubectl get componentstatuses
 
 	# create the pod permissive security policy
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" kubectl apply -f pod-security-policy-permissive.yaml
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" kubectl apply -f pod-security-policy-restricted.yaml
+	# Sometimes the api server responds to basic stuff, but needs for time for applies
+	# giving an error like:
+	#   error: unable to recognize "pod-security-policy-permissive.yaml": no matches for extensions/, Kind=PodSecurityPolicy
+	# until we find a good test for it ... just keep trying...
+	while ! ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" kubectl apply -f pod-security-policy-permissive.yaml; do
+		sleep 10
+	done
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" kubectl apply -f pod-security-policy-restricted.yaml
 
 	# create the rbac cluster roles
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" kubectl apply -f cluster-role-kube-apiserver-to-kubelet.yaml
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" kubectl apply -f cluster-role-binding-kube-apiserver-to-kubelet.yaml
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" kubectl apply -f cluster-role-restricted.yaml
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" kubectl apply -f cluster-role-binding-restricted.yaml
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" kubectl apply -f cluster-role-kube-apiserver-to-kubelet.yaml
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" kubectl apply -f cluster-role-binding-kube-apiserver-to-kubelet.yaml
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" kubectl apply -f cluster-role-restricted.yaml
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" kubectl apply -f cluster-role-binding-restricted.yaml
 
 	# create kube-dns
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" kubectl apply -f kube-dns.yaml
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" kubectl apply -f kube-dns.yaml
 
 	# create cilium
-	ssh -i "$SSH_KEYFILE" "${VM_USER}@${controller_ip}" kubectl apply -f cilium.yaml
+	ssh ${SSH_OPTIONS} "${VM_USER}@${controller_ip}" kubectl apply -f cilium.yaml
 }
 
 do_k8s_worker(){
@@ -210,44 +245,51 @@ do_k8s_worker(){
 		if [[ "$CLOUD_PROVIDER" == "azure" ]]; then
 			external_ip=$(az vm show -g "$RESOURCE_GROUP" -n "$instance" --show-details --query 'publicIps' -o tsv | tr -d '[:space:]')
 		fi
+		# Vagrant
+		if [[ "$CLOUD_PROVIDER" == "vagrant" ]]; then
+			external_ip=${instance}
+		fi
 
 		echo "Moving certficates to correct location for k8s on ${instance}..."
-		ssh -i "$SSH_KEYFILE" "${VM_USER}@${external_ip}" sudo mkdir -p /var/lib/kubelet/
-		ssh -i "$SSH_KEYFILE" "${VM_USER}@${external_ip}" sudo mv "${instance}-key.pem" "${instance}.pem" /var/lib/kubelet/
-		ssh -i "$SSH_KEYFILE" "${VM_USER}@${external_ip}" sudo mkdir -p /var/lib/kubernetes/
-		ssh -i "$SSH_KEYFILE" "${VM_USER}@${external_ip}" sudo mv ca.pem /var/lib/kubernetes/
-		ssh -i "$SSH_KEYFILE" "${VM_USER}@${external_ip}" sudo mv "${instance}.kubeconfig" /var/lib/kubelet/kubeconfig
-		ssh -i "$SSH_KEYFILE" "${VM_USER}@${external_ip}" sudo mkdir -p /var/lib/kube-proxy/
-		ssh -i "$SSH_KEYFILE" "${VM_USER}@${external_ip}" sudo mv kube-proxy.kubeconfig /var/lib/kube-proxy/kubeconfig
+		ssh ${SSH_OPTIONS} "${VM_USER}@${external_ip}" sudo mkdir -p /var/lib/kubelet/
+		ssh ${SSH_OPTIONS} "${VM_USER}@${external_ip}" sudo mv "${instance}-key.pem" "${instance}.pem" /var/lib/kubelet/
+		ssh ${SSH_OPTIONS} "${VM_USER}@${external_ip}" sudo mkdir -p /var/lib/kubernetes/
+		ssh ${SSH_OPTIONS} "${VM_USER}@${external_ip}" sudo mv ca.pem /var/lib/kubernetes/
+		ssh ${SSH_OPTIONS} "${VM_USER}@${external_ip}" sudo mv "${instance}.kubeconfig" /var/lib/kubelet/kubeconfig
+		ssh ${SSH_OPTIONS} "${VM_USER}@${external_ip}" sudo mkdir -p /var/lib/kube-proxy/
+		ssh ${SSH_OPTIONS} "${VM_USER}@${external_ip}" sudo mv kube-proxy.kubeconfig /var/lib/kube-proxy/kubeconfig
 
-		scp -i "$SSH_KEYFILE" "${DIR}/../etc/cni/net.d/"*.conf "${VM_USER}@${external_ip}":~/
+		scp ${SSH_OPTIONS} "${DIR}/../etc/cni/net.d/"*.conf "${VM_USER}@${external_ip}":~/
 
 		echo "Moving cni configs to correct location for k8s on ${instance}..."
-		ssh -i "$SSH_KEYFILE" "${VM_USER}@${external_ip}" sudo mkdir -p /etc/cni/net.d/
-		ssh -i "$SSH_KEYFILE" "${VM_USER}@${external_ip}" sudo mv 10-bridge.conf 99-loopback.conf /etc/cni/net.d/
+		ssh ${SSH_OPTIONS} "${VM_USER}@${external_ip}" sudo mkdir -p /etc/cni/net.d/
+		ssh ${SSH_OPTIONS} "${VM_USER}@${external_ip}" sudo mv 10-bridge.conf 99-loopback.conf /etc/cni/net.d/
 
 		echo "Copying k8s worker install script to ${instance}..."
-		scp -i "$SSH_KEYFILE" "${DIR}/install_kubernetes_worker.sh" "${VM_USER}@${external_ip}":~/
+		scp ${SSH_OPTIONS} "${DIR}/install_kubernetes_worker.sh" "${VM_USER}@${external_ip}":~/
 
-		ssh -i "$SSH_KEYFILE" "${VM_USER}@${external_ip}" sudo mkdir -p /etc/systemd/system/
+		ssh ${SSH_OPTIONS} "${VM_USER}@${external_ip}" sudo mkdir -p /etc/systemd/system/
 		services=( kubelet.service kube-proxy.service )
 		for service in "${services[@]}"; do
 			echo "Copying $service to ${instance}..."
-			scp -i "$SSH_KEYFILE" "${DIR}/../etc/systemd/system/${service}" "${VM_USER}@${external_ip}":~/
-			ssh -i "$SSH_KEYFILE" "${VM_USER}@${external_ip}" sudo mv "$service" /etc/systemd/system/
+			scp ${SSH_OPTIONS} "${DIR}/../etc/systemd/system/${service}" "${VM_USER}@${external_ip}":~/
+			ssh ${SSH_OPTIONS} "${VM_USER}@${external_ip}" sudo mv "$service" /etc/systemd/system/
 		done
 
 		echo "Running install_kubernetes_worker.sh on ${instance}..."
-		ssh -i "$SSH_KEYFILE" "${VM_USER}@${external_ip}" CLOUD_PROVIDER="${CLOUD_PROVIDER}" sudo -E  bash -c './install_kubernetes_worker.sh'
+		ssh ${SSH_OPTIONS} "${VM_USER}@${external_ip}" CLOUD_PROVIDER="${CLOUD_PROVIDER}" sudo -E  bash -c './install_kubernetes_worker.sh'
 
 		# cleanup the script after install
-		ssh -i "$SSH_KEYFILE" "${VM_USER}@${external_ip}" rm install_kubernetes_worker.sh
+		ssh ${SSH_OPTIONS} "${VM_USER}@${external_ip}" rm install_kubernetes_worker.sh
 	done
 }
 
 do_end_checks(){
 	if [[ "$CLOUD_PROVIDER" == "google" ]]; then
 		controller_ip=$(gcloud compute addresses describe "$PUBLIC_IP_NAME" --region "$REGION" --format 'value(address)')
+	fi
+	if [[ "$CLOUD_PROVIDER" == "vagrant" ]]; then
+		controller_ip=172.17.8.100
 	fi
 
 	# check that we can reach the kube-apiserver externally

--- a/vagrant/_configure.sh
+++ b/vagrant/_configure.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# This script is run by vagrant on startup.  Do not run it.
+#
+set -e
+set -o pipefail
+
+if grep vagrant /home/vagrant/.ssh/authorized_keys > /dev/null; then
+  echo "Disabling swap"
+  swapoff -a
+  echo "Setting noop scheduler"
+  echo noop > /sys/block/sda/queue/scheduler
+  echo  "Disabling IPv6"
+  echo "net.ipv6.conf.all.disable_ipv6 = 1
+        net.ipv6.conf.default.disable_ipv6 = 1
+        net.ipv6.conf.lo.disable_ipv6 = 1" >> /etc/sysctl.conf
+  sysctl -p
+fi

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# This script provisions a cluster running in Vagrant with ubuntu os
+# and provisions a kubernetes cluster on it.
+#
+# The script assumes you already have Vagrant and VirtualBox installed.
+#
+set -e
+set -o pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="${DIR}/../scripts"
+
+export CLOUD_PROVIDER="vagrant"
+export VM_USER="vagrant"
+export WORKERS=${WORKERS:-0}
+
+export SSH_CONFIG="${DIR}/../.vagrant/ssh_config"
+export SSH_KEYFILE="~/.vagrant.d/insecure_private_key"
+export SSH_OPTIONS="-F ${SSH_CONFIG}"
+export RESOURCE_GROUP=${RESOURCE_GROUP:-kubernetes-clear-linux-snowflake}
+
+if [[ $1 == "clean" ]]; then
+  vagrant destroy -f
+else
+  vagrant up
+  vagrant ssh-config > ${SSH_CONFIG}
+  "${SCRIPT_DIR}/provision.sh"
+fi


### PR DESCRIPTION
* Added Vagrantfile and support pieces to make vagrant VMs work
* Updated ssh/scp commands to use SSH_OPTIONS variable as argument
  so that I could use vagrant's ssh config file easily
* Added some loops around kubectl early commands to deal with slow VMs
* Unfortunately Clear linux doesn't seem to have vagrant boxes, so used
  ubuntu for now like how gcloud scripts already do.

```
$ vagrant/setup.sh
==> worker-node-0: VM not created. Moving on...
==> controller-node: VM not created. Moving on...
Bringing machine 'controller-node' up with 'virtualbox' provider...
Bringing machine 'worker-node-0' up with 'virtualbox' provider...
==> controller-node: Importing base box 'bento/ubuntu-16.04'...
...
...
Testing a curl to the apiserver...
{
  "major": "1",
  "minor": "8",
  "gitVersion": "v1.8.3",
  "gitCommit": "f0efb3cb883751c5ffdbe6d515f3cb4fbe7b7acd",
  "gitTreeState": "clean",
  "buildDate": "2017-11-08T18:27:48Z",
  "goVersion": "go1.8.3",
  "compiler": "gc",
  "platform": "linux/amd64"
}
Cluster "kubernetes-clear-linux-snowflake" set.
User "admin" set.
Context "kubernetes-clear-linux-snowflake" modified.
Switched to context "kubernetes-clear-linux-snowflake".
Checking get nodes...
NAME            STATUS    ROLES     AGE       VERSION
worker-node-0   Ready     <none>    17s       v1.8.3

```